### PR TITLE
Update for PHP 7

### DIFF
--- a/sphinxapi.php
+++ b/sphinxapi.php
@@ -427,7 +427,7 @@ class SphinxClient
 	/////////////////////////////////////////////////////////////////////////////
 
 	/// create a new client object and fill defaults
-	function SphinxClient ()
+	function __construct()
 	{
 		// per-client-object settings
 		$this->_host		= "localhost";


### PR DESCRIPTION
Update for PHP7 with new constructor name.

See:

http://php.net/manual/en/migration70.deprecated.php